### PR TITLE
feat: add heap size metrics parsing for newest pm2

### DIFF
--- a/exporter.js
+++ b/exporter.js
@@ -64,7 +64,7 @@ function metrics() {
             let value;
             if (name === 'Loop delay') {
               value = parseFloat(p.pm2_env.axm_monitor[name].value.match(/^[\d.]+/)[0]);
-            } else if (name.match(/Event Loop Latency/)) {
+            } else if (name.match(/Event Loop Latency|Heap Size/)) {
               value = parseFloat(p.pm2_env.axm_monitor[name].value.toString().split('m')[0]);
             } else {
               value = p.pm2_env.axm_monitor[name].value;


### PR DESCRIPTION
In the latest version of pm2, Heap Size and Used Heap Size has been
introduced. Their value need to be converted to float as Event Loop
Latency metrics values.

See: https://github.com/Unitech/PM2/blob/master/CHANGELOG.md#340