### PR TITLE
feat: add different log levels depending on logging content

### DIFF
--- a/exporter.js
+++ b/exporter.js
@@ -3,6 +3,7 @@
 const http = require('http');
 const prom = require('prom-client');
 const pm2 = require('pm2');
+const logger = require('pino-http')()
 
 const io = require('@pm2/io');
 
@@ -41,7 +42,7 @@ function metrics() {
   return pm2c('list')
     .then(list => {
       list.forEach(p => {
-        console.log(p, p.exec_interpreter, '>>>>>>');
+        logger.debug(p, p.exec_interpreter, '>>>>>>');
         const conf = {
           id: p.pm_id,
           name: p.name,
@@ -88,7 +89,7 @@ function metrics() {
 
             values[metricName] = value;
           } catch (error) {
-            console.log(error);
+            logger.error(error);
           }
         }
 
@@ -107,7 +108,7 @@ function metrics() {
       return registry.metrics()
     })
     .catch(err => {
-      console.log(err);
+      logger.error(err);
     });
 }
 
@@ -128,7 +129,7 @@ function exporter() {
   const host = conf.host || '0.0.0.0';
 
   server.listen(port, host);
-  console.log('pm2-prometheus-exporter listening at %s:%s', host, port);
+  console.info('pm2-prometheus-exporter listening at %s:%s', host, port);
 }
 
 exporter();

--- a/package-lock.json
+++ b/package-lock.json
@@ -3209,6 +3209,16 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "fast-redact": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-1.5.0.tgz",
+      "integrity": "sha512-Afo61CgUjkzdvOKDHn08qnZ0kwck38AOGcMlvSGzvJbIab6soAP5rdoQayecGCDsD69AiF9vJBXyq31eoEO2tQ=="
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+    },
     "fault": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.2.tgz",
@@ -3380,6 +3390,11 @@
         "rimraf": "2.6.3",
         "write": "1.0.3"
       }
+    },
+    "flatstr": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.9.tgz",
+      "integrity": "sha512-qFlJnOBWDfIaunF54/lBqNKmXOI0HqNhu+mHkLmbaBXlS71PUd9OjFOdyevHt/aHoHB1+eW7eKHgRKOG5aHSpw=="
     },
     "flatted": {
       "version": "2.0.0",
@@ -7607,6 +7622,33 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pino": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-5.12.0.tgz",
+      "integrity": "sha512-tXlxRVUuYrsS8jfmki3lennOcibfmGnloitY8Zn1HUMNNtOCiYH8ctQFdK+cg/7QmE2vEnfMNAIK8H3/hPBUQw==",
+      "requires": {
+        "fast-redact": "^1.4.4",
+        "fast-safe-stringify": "^2.0.6",
+        "flatstr": "^1.0.9",
+        "pino-std-serializers": "^2.3.0",
+        "quick-format-unescaped": "^3.0.2",
+        "sonic-boom": "^0.7.3"
+      }
+    },
+    "pino-http": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-4.1.0.tgz",
+      "integrity": "sha512-IRmQMLFK2M/N05T+yitm7IL1duTjs5YlsfVCV6Pm5akFl6mIbr/fx9K2F4JZtEiwRFfyGb1A9MRJ/YhKd+3TUw==",
+      "requires": {
+        "pino": "^5.0.0",
+        "pino-std-serializers": "^2.1.0"
+      }
+    },
+    "pino-std-serializers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.3.0.tgz",
+      "integrity": "sha512-klfGoOsP6sJH7ON796G4xoUSx2fkpFgKHO4YVVO2zmz31jR+etzc/QzGJILaOIiCD6HTCFgkPx+XN8nk+ruqPw=="
+    },
     "pkg-conf": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
@@ -7894,6 +7936,11 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "quick-format-unescaped": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.2.tgz",
+      "integrity": "sha512-FXTaCkwvpIlkdKeGDNgcq07SXWS383noQUuZjvdE1QcTt+eLuqof6/BDiEPqB59FWLie/l91+HtlJSw7iCViSA=="
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -9529,6 +9576,14 @@
       "requires": {
         "agent-base": "~4.2.0",
         "socks": "~2.2.0"
+      }
+    },
+    "sonic-boom": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.3.tgz",
+      "integrity": "sha512-A9EyoIeLD+g9vMLYQKjNCatJtAKdBQMW03+L8ZWWX/A6hq+srRCwdqHrBD1R8oSMLXov3oHN13dljtZf12q2Ow==",
+      "requires": {
+        "flatstr": "^1.0.9"
       }
     },
     "sort-keys": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Produces Metrics of Pm2 of running instances.little updated version of https://github.com/burningtree/pm2-prometheus-exporter, any PR is appriciated.",
   "dependencies": {
     "@pm2/io": "^3.1.1",
+    "pino-http": "^4.1.0",
     "pm2": "^3.3.1",
     "prom-client": "^11.2.1"
   },


### PR DESCRIPTION
The exporter is currently to verbose. The native nodejs console API doesn't manage many levels of verbosity depending on the content you want to display. They're all aliases of each other except for the distinction info/error.

In the current exporter's implementation, we can distinguish many levels of messages :
- info : when starting the server
- debug : when prompting *p* variable's value
- error : when catching errors

That's why a dependency may be needed.

Tell me what you think about it.