### PR TITLE
Always parseFloat value and add a warning if NaN

### DIFF
--- a/exporter.js
+++ b/exporter.js
@@ -73,7 +73,13 @@ function metrics() {
             } else if (name.match(/Event Loop Latency|Heap Size/)) {
               value = parseFloat(p.pm2_env.axm_monitor[name].value.toString().split('m')[0]);
             } else {
-              value = p.pm2_env.axm_monitor[name].value;
+              value = parseFloat(p.pm2_env.axm_monitor[name].value);
+            }
+
+            if (isNaN(value)) {
+              logger.warn('Ignoring metric name "%s" as value "%s" is not a number', name, value);
+
+              continue;
             }
 
             const metricName = prefix + '_' + name.replace(/[^A-Z0-9]+/gi, '_').toLowerCase();


### PR DESCRIPTION
I just tried this plugin with plugin pm2-logrotate already installed. Problem is that a metric called `Global logs size` returns a size in MB.
![image](https://user-images.githubusercontent.com/7634514/59041674-5f221400-8879-11e9-9d5d-ed923f0f0401.png)
Which was throwing this error:
```
2|pm2-metrics  | {"level":50,"time":1559825879721,"pid":27595,"hostname":"preprod","msg":"Value is not a valid number: 15.07 MB","stack":"TypeError: Value is not a valid number: 15.07 MB\n    at /home/debian/.pm2/modules/pm2-metrics/node_modules/prom-client/lib/gauge.js:228:10\n    at Gauge.set (/home/debian/.pm2/modules/pm2-metrics/node_modules/prom-client/lib/gauge.js:91:32)\n    at Object.keys.forEach.k (/home/debian/.pm2/modules/pm2-metrics/node_modules/pm2-metrics/exporter.js:105:17)\n    at Array.forEach (<anonymous>)\n    at list.forEach.p (/home/debian/.pm2/modules/pm2-metrics/node_modules/pm2-metrics/exporter.js:96:29)\n    at Array.forEach (<anonymous>)\n    at pm2c.then.list (/home/debian/.pm2/modules/pm2-metrics/node_modules/pm2-metrics/exporter.js:44:12)\n    at processTicksAndRejections (internal/process/next_tick.js:81:5)","type":"Error","v":1}
```

So I propose to always `parseFloat` values. Furthermore to avoid having your prometheus endpoint crash for only one NaN metric, I propose to ignore NaN values and simply log a warning.

What do you think?