### PR TITLE
fix: uptime as 0 if status is not online

### DIFF
--- a/exporter.js
+++ b/exporter.js
@@ -53,7 +53,7 @@ const metrics = () => {
           up: p.pm2_env.status === 'online' ? 1 : 0,
           cpu: p.monit.cpu,
           memory: p.monit.memory,
-          uptime: Math.round((Date.now() - p.pm2_env.pm_uptime) / 1000),
+          uptime: p.pm2_env.status === 'online' ? Math.round((Date.now() - p.pm2_env.pm_uptime) / 1000) : 0,
           instances: p.pm2_env.instances || 1,
           restarts: p.pm2_env.restart_time,
           prev_restart_delay: p.pm2_env.prev_restart_delay

--- a/exporter.js
+++ b/exporter.js
@@ -49,11 +49,13 @@ const metrics = () => {
           node_version: p.pm2_env.node_version
         };
 
+        const isOnline = p.pm2_env.status === 'online';
+
         const values = {
-          up: p.pm2_env.status === 'online' ? 1 : 0,
+          up: isOnline ? 1 : 0,
           cpu: p.monit.cpu,
           memory: p.monit.memory,
-          uptime: p.pm2_env.status === 'online' ? Math.round((Date.now() - p.pm2_env.pm_uptime) / 1000) : 0,
+          uptime: isOnline ? Math.round((Date.now() - p.pm2_env.pm_uptime) / 1000) : 0,
           instances: p.pm2_env.instances || 1,
           restarts: p.pm2_env.restart_time,
           prev_restart_delay: p.pm2_env.prev_restart_delay


### PR DESCRIPTION
Address #68 

`pm2_uptime` isn't 0 if the service is down. This PR adds logic to only output the uptime if the service `status` is online, else return `0`